### PR TITLE
Original filename issue fixed

### DIFF
--- a/lib/carrierwave/storage/postgresql_lo.rb
+++ b/lib/carrierwave/storage/postgresql_lo.rb
@@ -55,6 +55,10 @@ module CarrierWave
           @oid ||= @uploader.identifier
         end
 
+        def original_filename
+          identifier.to_s
+        end
+
       end
 
       def store!(file)


### PR DESCRIPTION
Abstract does not have `original_filename` in newer versions of Ruby anymore. So we have to emulate it to make things work.
