### PR TITLE
Fix connection method call deprecation warning introduced in ActiveRecord 4.0

### DIFF
--- a/lib/carrierwave/storage/postgresql_lo.rb
+++ b/lib/carrierwave/storage/postgresql_lo.rb
@@ -48,7 +48,7 @@ module CarrierWave
         alias :size :file_length
 
         def connection
-          @connection ||= @uploader.model.connection.raw_connection
+          @connection ||= @uploader.model.class.connection.raw_connection
         end
 
         def identifier
@@ -78,7 +78,7 @@ module CarrierWave
       end
 
       def connection
-        @connection ||= uploader.model.connection.raw_connection
+        @connection ||= uploader.model.class.connection.raw_connection
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/diogob/carrierwave-postgresql/issues/8
