### PR TITLE
when generating url, model class name should be underscored

### DIFF
--- a/lib/carrierwave/storage/postgresql_lo.rb
+++ b/lib/carrierwave/storage/postgresql_lo.rb
@@ -8,7 +8,7 @@ module CarrierWave
         end
 
         def url
-          "/#{@uploader.model.class.name.underscore}_#{@uploader.mounted_as.underscore}/#{identifier}"
+          "/#{@uploader.model.class.name.underscore.gsub('/', '_')}_#{@uploader.mounted_as.to_s.underscore}/#{identifier}"
         end
 
         def read

--- a/spec/storage/file_spec.rb
+++ b/spec/storage/file_spec.rb
@@ -16,6 +16,11 @@ describe CarrierWave::Storage::PostgresqlLo::File do
   describe "#url" do
     subject{ file.url }
     it{ should == "/test_file/0" }
+
+    context "on a namespaced model" do
+      let(:test_model){ Namespace::Test.new }
+      it{ should == "/namespace_test_file/0" }
+    end
   end
 
   describe "#write" do

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -16,3 +16,7 @@ end
 class Test < ActiveRecord::Base
 end
 
+module Namespace
+  class Test < ActiveRecord::Base
+  end
+end


### PR DESCRIPTION
In the url method, calling @uploader.model.class.name.downcase on namespaced model will generate something like "namespace::model", which is not a valid url format. Solved this by calling underscore instead.
