### PR TITLE
Ensuring identifier is always an integer

### DIFF
--- a/lib/carrierwave/storage/postgresql_lo.rb
+++ b/lib/carrierwave/storage/postgresql_lo.rb
@@ -53,7 +53,7 @@ module CarrierWave
         end
 
         def identifier
-          @oid ||= @uploader.identifier
+          @oid ||= @uploader.identifier.to_i
         end
 
         def original_filename


### PR DESCRIPTION
This fixed a bug I was getting when editing a file, where the identifier was getting set to a string. This caused a 'no implicit conversion of String to Integer' bug in the #write method when calling connection.lo_open. On a side note, the file uploader was being used on an ActiveAdmin form (not sure if that had something to do with it).
