### PR TITLE
Stop reading oid from the mounted on attributes.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,3 +58,6 @@ DEPENDENCIES
   pg
   rake
   rspec
+
+BUNDLED WITH
+   1.10.4

--- a/lib/carrierwave/storage/postgresql_lo.rb
+++ b/lib/carrierwave/storage/postgresql_lo.rb
@@ -71,11 +71,12 @@ module CarrierWave
 
       def retrieve!(identifier)
         raise "This uploader must be mounted in an ActiveRecord model to work" unless uploader.model
+        @oid = identifier
         CarrierWave::Storage::PostgresqlLo::File.new(uploader)
       end
 
       def identifier
-        @oid ||= uploader.model.read_attribute(uploader.mounted_as) || connection.lo_creat
+        @oid ||= connection.lo_creat
       end
 
       def connection

--- a/spec/storage/file_spec.rb
+++ b/spec/storage/file_spec.rb
@@ -27,7 +27,7 @@ describe CarrierWave::Storage::PostgresqlLo::File do
   end
 
   describe "#write" do
-    it("should write the file using the lo interface") do 
+    it("should write the file using the lo interface") do
       expect(file.write(tempfile)).to eq file_content.length
     end
 

--- a/spec/storage/postgresql_lo_spec.rb
+++ b/spec/storage/postgresql_lo_spec.rb
@@ -31,7 +31,7 @@ describe CarrierWave::Storage::PostgresqlLo do
     end
 
     context "when we have it mounted" do
-      let(:uploader){ double('an uploader', :model => test_model, :mounted_as => :file) }
+      let(:uploader){ double('an uploader', :model => test_model) }
       let(:lo){ storage.store!(file) }
       before do
         uploader.stub(:identifier) do


### PR DESCRIPTION
If the uploader was mounted using the mount_on option, then it will currently try to read the oid from the wrong attribute.

For example, with the uploader

```ruby
mount_uploader :file, FileUploader, mount_on: :file_oid
```

it will try to read the oid from the `file` column instead of from the `file_oid` column where it is stored.