### PR TITLE
Update gemspec to reflect incompatibility with carrierwave 2.0

### DIFF
--- a/carrierwave-postgresql.gemspec
+++ b/carrierwave-postgresql.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{lib}/**/*"] + ["LICENSE.txt", "Rakefile", "README.md"]
 
-  s.add_dependency "carrierwave", ">= 0.10.0"
+  s.add_dependency "carrierwave", ">= 0.10.0", "< 2.0"
 
   s.add_development_dependency "activerecord", ">= 4.0.1"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
bumping rubies/gems in a project and I pulled carrierwave 2.0.1 (with just 'carrierwave-postgresql' in my Gemfile). This seems to throw the following error: "NotImplementedError:
       Need to implement #cache! if you want to use CarrierWave::Storage::PostgresqlLo as a cache storage."

Specifying "gem 'carrierwave', '~> 1.0'" in my Gemfile allowed my test to pass. 

I believe this change to the gemspec should "fix" it, but haven't tested.